### PR TITLE
Translate No results

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,7 @@
             <template slot="city" slot-scope="props">test column - {{ props.row.name }}</template>
             <!-- Will be applied on the row with _id tiger -->
             <template slot="_tiger" slot-scope="props">test row - {{ props.row.name }}</template>
-            <template slot="no-rows">Geen resultaten</template>
+            <template slot="no-rows">No results</template>
             <template slot="sort-icon" slot-scope="props">{{ props.direction === null ? 'null' : (props.direction ? 'up' : 'down') }}</template>
             <template slot="toggle-children-icon" slot-scope="props">{{ props.expanded ? 'open' : 'closed' }}</template>
         </vue-ads-table-tree>


### PR DESCRIPTION
Hi,

Thanks for the great library. I am [evaluating](https://github.com/cylc/cylc-ui/issues/78#issuecomment-498491939) if we are able to use it to display a screen from a legacy GTK application with tables+hierarchy.

While adding an empty table, I noticed the text "Geen resultaten" that looked like Dutch? Google Translate works for Dutch and gives me back No results... and there are other parts of the code with No results... so I think it should be OK to translate this one?

Cheers
Bruno