### PR TITLE
Accept empty columns without console warnings

### DIFF
--- a/src/mixins/columns.js
+++ b/src/mixins/columns.js
@@ -66,8 +66,10 @@ export default {
                 }
             });
 
-            if (!columns.find(column => column.collapseIcon)) {
-                Vue.set(columns[0], 'collapseIcon', true);
+            if (columns.length > 0) {
+                if (!columns.find(column => column.collapseIcon)) {
+                    Vue.set(columns[0], 'collapseIcon', true);
+                }
             }
 
             // todo check to remove this to the styling mixin


### PR DESCRIPTION
At the moment when you have 

```javascript
export default {
  data() => ({
      columns: [],
      rows: [],
      classes: {},
      filter: '',
      start: 0,
      end: 100
  }),
  ...
}
```

And use

```html
<vue-ads-table
    :columns="columns"
    :rows="rows"
    :classes="classes"
    :filter="filter"
    :start="start"
    :end="end"
    @filter-change="filterChanged"
>
  <!-- Will be applied on the name column for the rows with an _id of tiger -->
  <template slot="name_tiger" slot-scope="props">test cell - {{ props.row.name }}</template>
  <!-- Will be applied on the city column -->
  <template slot="city" slot-scope="props">test column - {{ props.row.city }}</template>
  <!-- Will be applied on the row with _id tiger -->
  <template slot="_tiger" slot-scope="props">test row - {{ props.row[props.column.property] }}</template>
  <template slot="no-rows">Geen resultaten</template>
  <template slot="sort-icon" slot-scope="props">{{ props.direction === null ? 'null' : (props.direction ? 'up' : 'down') }}</template>
  <template slot="toggle-children-icon" slot-scope="props">{{ props.expanded ? 'open' : 'closed' }}</template>
</vue-ads-table>
```

The component is rendered, and it displays a message about no results, but the browser console has:

```
[Vue warn]: Error in callback for immediate watcher "columns": "TypeError: right-hand side of 'in' should be an object, got undefined"

found in

---> <VueAdsTable>
       <VCard>
         <MaterialCard> at src/components/material/Card.vue
           <Suite> at src/views/Suite.vue
             <VContent>
               <Default> at src/layouts/Default.vue
                 <VApp>
                   <App> at src/App.vue
                     <Root> vue.runtime.esm.js:619
    VueJS 105
    run es6.promise.js:75
    notify es6.promise.js:92
    flush _microtask.js:18
```

I think it is happening as when no column is found on an event handler method, then we access `columns[0]`, without checking whether there is any column first.

![image](https://user-images.githubusercontent.com/304786/58849238-ba1f0400-86dd-11e9-908f-ccd6fed31b6c.png)

Tested the fix in this PR by fixing the code in the `node_modules` folder and checking the browser console.