### PR TITLE
Allow "loading" and "no-rows" slots to be used with VueAdsTableContainer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,22 +217,26 @@ All three contains a slot-scope which contains the following parameters:
 
 #### 2. No rows slot
 
-If no rows are loaded, the table displays 'No results found.'. You can replace this message by the scoped slot `no-rows`.
+If no rows are loaded, the table displays 'No results found.'. You can replace this message by the `no-rows` slot.
 
-#### 3. Sort icon slot
+#### 3. Loading slot
+
+While rows are being loaded asynchronously, the table displays 'Loading...'. You can replace this message by the `loading` slot.
+
+#### 4. Sort icon slot
 
 If you want to customize the sort icon add a scoped slot with the name `sort-icon`.
 The scope contains only one parameter:
 
 - `direction`: *(type: boolean or null)* The direction is null if the column is not sorted, true if it's sorted asc and false if it's sorted desc.
 
-#### 4. Toggle children icon slot
+#### 5. Toggle children icon slot
 
 If you want to customize the toggle children icon add a scoped slot with the name `toggle-children-icon`.
 The scope contains two parameters:
 
 - `expanded`: *(type: boolean)* Indicates if the children are visible or not.
-- `loading`: *(type: boolean)* Indicates if the chilrend are currently loading.
+- `loading`: *(type: boolean)* Indicates if the children are currently loading.
 
 ### Example
 

--- a/src/TableContainerApp.vue
+++ b/src/TableContainerApp.vue
@@ -23,7 +23,7 @@
             <!--<template slot="city" slot-scope="props">test column - {{ props.row.city }}</template>-->
             <!--&lt;!&ndash; Will be applied on the row with _id tiger &ndash;&gt;-->
             <!--<template slot="_tiger" slot-scope="props">test row - {{ props.row[props.column.property] }}</template>-->
-            <!--<template slot="no-rows">Geen resultaten</template>-->
+            <!--<template slot="no-rows"><i>Geen resultaten</i></template>-->
             <!--<template slot="sort-icon" slot-scope="props">{{ props.direction === null ? 'null' : (props.direction ? 'up' : 'down') }}</template>-->
             <!--<template slot="toggle-children-icon" slot-scope="props">{{ props.expanded ? 'open' : 'closed' }}</template>-->
         </vue-ads-table>

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -34,7 +34,7 @@
                         <slot name="loading">Loading...</slot>
                     </span>
                     <span v-else>
-                        <slot name="no-rows">No results found</slot>
+                        <slot name="no-rows">No results found.</slot>
                     </span>
                 </td>
             </tr>

--- a/src/components/TableContainer.vue
+++ b/src/components/TableContainer.vue
@@ -45,7 +45,14 @@
             @total-filtered-rows-change="totalFilteredRowsChanged"
             @export="exportTable"
             @selection-change="selectionChanged"
-        />
+        >
+            <template #loading>
+                <slot name="loading"></slot>
+            </template>
+            <template #no-rows>
+                <slot name="no-rows"></slot>
+            </template>
+        </vue-ads-table>
         <slot name="bottom"
               :total="total"
               :page="page"

--- a/src/mixins/slots.js
+++ b/src/mixins/slots.js
@@ -10,11 +10,9 @@ export default {
 
     computed: {
         currentSlots () {
-            if (Object.keys(this.slots).length === 0) {
-                return Object.assign(this.$slots, this.$scopedSlots);
-            }
-
-            return this.slots;
+            return {
+                ...this.slots, ...this.$scopedSlots,
+            };
         },
 
         sortIconSlot () {


### PR DESCRIPTION
Otherwise they have no effect, and only work with the basic table (`VueAdsTable`).