### PR TITLE
Sort the table as usual when "sort-icon" slot is provided.

### DIFF
--- a/src/mixins/cell/sortCell.js
+++ b/src/mixins/cell/sortCell.js
@@ -32,7 +32,7 @@ export default {
 
     methods: {
         sortIcon (createElement) {
-            return this.sortIconSlot ?
+            let iconNode = this.sortIconSlot ?
                 this.sortIconSlot({
                     direction: this.column.direction,
                 }) :
@@ -40,14 +40,23 @@ export default {
                     'i',
                     {
                         class: this.sortIconClasses,
-                        on: {
-                            click: (event) => {
-                                event.stopPropagation();
-                                this.$emit('sort', this.column);
-                            },
-                        },
                     },
                 );
+
+            return createElement(
+                'span',
+                {
+                    on: {
+                        click: (event) => {
+                            event.stopPropagation();
+                            this.$emit('sort', this.column);
+                        },
+                    },
+                },
+                [
+                    iconNode,
+                ]
+            );
         },
     },
 };


### PR DESCRIPTION
Similar to the "toggle-children-icon" I would expect "sort-icon" slot to let the user provide custom icon template, but for the actual functionality (toggling/sorting) to be done on the base component.