### PR TITLE
Set min-width for the top toolbar, so it is usable with narrow tables.

### DIFF
--- a/src/components/TableContainer.vue
+++ b/src/components/TableContainer.vue
@@ -6,7 +6,7 @@
         >
             <div class="vue-ads-flex vue-ads-py-3">
                 <div class="vue-ads-w-3/4"></div>
-                <div class="vue-ads-w-1/4 vue-ads-flex">
+                <div class="vue-ads-w-1/4 vue-ads-flex" style="min-width: 180px;">
                     <vue-ads-form
                         :class="filterClasses"
                         :style="{'min-width': 0}"


### PR DESCRIPTION
Maybe there is a better fix, but I went with `style` attribute for the following reasons:
* Tailwind css doesn't provide a suitable class for the purpose.
* I'd like to avoid creating `<style>` sections in project code, so that vue-ads-table-tree styles don't have to be imported, only tailwind css if necessary.