### PR TITLE
Remove tailwind base and components deps, so the look of html…

### DIFF
--- a/src/assets/css/tailwind.css
+++ b/src/assets/css/tailwind.css
@@ -1,5 +1,1 @@
-@tailwind base;
-
-@tailwind components;
-
 @tailwind utilities;


### PR DESCRIPTION
… elements is not modified, when vue-ads-table-tree styles are imported (important when using vue-ads-table-tree as a dependency).
This does not effect (the effect is hardly noticeable) the demo apps as index.html links 'tailwind.min.css'.